### PR TITLE
Republic.jl v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.6'
+          - '1.10'
           - '1.11'
-          - '1.12'
           - 'pre'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 name = "Republic"
 uuid = "27243419-9dde-4721-b67c-fd63626fea7f"
 authors = ["AntonOresten <antonoresten@proton.me> and contributors"]
-version = "1.0.1"
+version = "2.0.0"
+
+[compat]
+julia = "1.6"
 
 [workspace]
 projects = ["test"]
-
-[compat]
-julia = "1.11"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Re-exports exported names (instead of marking them `public`). Replaces [Reexport
 
 ```julia
 @republic reexport=true using Foo             # exported → re-export
-@republic reexport=true using Foo: pub, exp   # public name `pub` is not exported
 ```
 
 ### Combined: full API forwarding
@@ -66,39 +65,6 @@ Re-exports exported names (instead of marking them `public`). Replaces [Reexport
 ```julia
 @republic reexport=true inherit=true using Foo  # re-export + inherit public
 ```
-
-### Full example
-
-```julia
-module MyPackage
-    using Republic
-
-    # Baseline: mark specific names
-    @republic using Foo: bar, baz
-    @republic import Foo: qux       # qux is extensible + public
-
-    # Inherit: forward the full public API
-    @republic inherit=true using CorePkg
-
-    # Re-export + inherit: the CUDA.jl pattern
-    @republic reexport=true inherit=true using BasePkg
-
-    # Blocks
-    @republic reexport=true inherit=true begin
-        using Dep1
-        using Dep2
-    end
-end
-```
-
-## Discovery API
-
-```julia
-exported_names(mod)   # names that are `export`ed — works on any Julia version
-public_names(mod)     # names that are `public` but not `export`ed — version-invariant
-```
-
-These two functions partition a module's API into non-overlapping sets. On Julia 1.11+, `public_names` uses `Base.ispublic`. On earlier versions, it reads from Republic's internal tracking (populated by `@public` and `@republic`).
 
 ## Overriding visibility
 

--- a/README.md
+++ b/README.md
@@ -5,74 +5,130 @@
 
 > Dependencies united under one public API.
 
-Republic.jl re-publicizes names from upstream modules, making them part of your module's public API without exporting them into the caller's namespace. Like [Reexport.jl](https://github.com/JuliaLang/Reexport.jl), but for Julia's [`public`](https://docs.julialang.org/en/v1.11/base/base/#public) keyword (introduced in Julia 1.11).
+Republic.jl manages Julia's [`public`](https://docs.julialang.org/en/v1.11/base/base/#public) visibility across module boundaries and Julia versions. It provides:
 
-## Usage
+- **`@public`** — declare names as public API, with cross-version tracking
+- **`@republic`** — forward upstream names into your module's public API
+- **`public_names` / `exported_names`** — version-invariant discovery functions
+
+On Julia 1.11+, Republic uses the native `public` keyword. On earlier versions, it tracks declarations internally and degrades gracefully.
+
+## `@public`: Declaring Public API
+
+```julia
+using Republic: @public
+
+@public foo              # single name
+@public foo, bar, baz    # multiple names
+@public @my_macro        # macro name
+```
+
+Replaces [SciMLPublic.jl](https://github.com/SciML/SciMLPublic.jl) and `@compat public` from [Compat.jl](https://github.com/JuliaLang/Compat.jl). Unlike those packages, Republic tracks declarations for cross-version discovery via `public_names(mod)`.
+
+## `@republic`: Forwarding Public API
+
+`@republic` has two orthogonal, composable flags:
+
+| | `inherit=false` (default) | `inherit=true` |
+|---|---|---|
+| **`reexport=false`** (default) | exported → `public` | exported → `public`, public-only → import + `public` |
+| **`reexport=true`** | exported → re-`export` | exported → re-`export`, public-only → import + `public` |
+
+### Baseline (no flags)
+
+Marks what you bring in as `public`. No wildcard name discovery.
+
+```julia
+@republic using Foo                 # exported names → public
+@republic using Foo: bar, baz       # specific names → public
+@republic import Foo: bar           # import semantics + public
+```
+
+### `inherit=true`
+
+Discovers public-only names upstream. Imports them and marks them `public`.
+
+```julia
+@republic inherit=true using Foo    # all API names → public
+```
+
+### `reexport=true`
+
+Re-exports exported names (instead of marking them `public`). Replaces [Reexport.jl](https://github.com/JuliaLang/Reexport.jl).
+
+```julia
+@republic reexport=true using Foo   # exported → re-export
+```
+
+### Combined: full API forwarding
+
+```julia
+@republic reexport=true inherit=true using Foo  # re-export + inherit public
+```
+
+### Full example
 
 ```julia
 module MyPackage
     using Republic
 
-    # All of Foo's public and exported names become public in MyPackage.
-    # Unlike plain `using Foo`, this also brings in public (non-exported) names
-    @republic using Foo
-
-    # Qualified to avoid clutter
+    # Baseline: mark specific names
     @republic using Foo: bar, baz
+    @republic import Foo: qux       # qux is extensible + public
 
-    # The alias `F` becomes public in `MyPackage`
-    @republic using Foo: Foo as F
+    # Inherit: forward the full public API
+    @republic inherit=true using CorePkg
 
-    # Only `Bar` gets imported and marked public
-    @republic import Bar
-
-    # `baz` can be extended within MyPackage, and is marked public
-    @republic import Bar: baz
+    # Re-export + inherit: the CUDA.jl pattern
+    @republic reexport=true inherit=true using BasePkg
 
     # Blocks
-    @republic begin
-        using Foo
-        using Bar
+    @republic reexport=true inherit=true begin
+        using Dep1
+        using Dep2
     end
 end
 ```
 
-Names re-publicized in `MyPackage` become accessible via qualified access (`MyPackage.bar`) without being brought into scope by `using MyPackage`. This is useful for packages that want to conveniently expose a broad API surface from different packages without polluting the caller's namespace.
-
-The main use case for re-publicizing is lightweight "Core" or "Base" packages — like [StaticArraysCore](https://github.com/JuliaArrays/StaticArraysCore.jl/), [EnzymeCore](https://github.com/EnzymeAD/Enzyme.jl/tree/main/lib/EnzymeCore), and [ManifoldsBase](https://github.com/JuliaManifolds/ManifoldsBase.jl) — whose types and functions you want to surface as part of your package's API. This also works for heavier packages whose interfaces you may be implementing, but make sure to `@republic` a qualified import to avoid clutter!
-
-## Re-exporting
-
-By default, `@republic` makes everything public. To also re-export names that were exported upstream, use `reexport=true`:
+## Discovery API
 
 ```julia
-@republic reexport=true using Foo
+exported_names(mod)   # names that are `export`ed — works on any Julia version
+public_names(mod)     # names that are `public` but not `export`ed — version-invariant
 ```
 
-With `reexport=true`, exported names are re-exported (like Reexport.jl), and public-only names are marked public. Republic never promotes a public-only name to exported — that is a deliberate choice left to the user (see below).
+These two functions partition a module's API into non-overlapping sets. On Julia 1.11+, `public_names` uses `Base.ispublic`. On earlier versions, it reads from Republic's internal tracking (populated by `@public` and `@republic`).
 
 ## Overriding visibility
 
-Julia does not allow a name to be marked with both `public` and `export`. This only matters if a name is public upstream but you want to export it in your module. To export a public-only name, declare the `export` *before* `@republic`:
+Julia does not allow a name to be both `public` and `export`ed. Republic respects pre-existing declarations:
 
 ```julia
 module MyPackage
     using Republic
-    export bar            # bar will be exported, not just public
-    @republic using Foo   # skips `public` for bar since it's already exported
+    export bar                                  # already exported
+    @republic republish=true using Foo          # skips `public bar`
 end
 ```
-
-Alternatively, use qualified imports to keep `@republic` and `export` separate:
 
 ```julia
 module MyPackage
     using Republic
-    using Foo: bar
-    export bar
-    @republic using Foo: baz, qux  # only these become public
+    public bar                                  # already public
+    @republic reexport=true using Foo           # skips `export bar`
 end
 ```
+
+## Migration from v1.x
+
+The default behavior of `@republic` changed in v2.0:
+
+| v1.x | v2.0 equivalent |
+|---|---|
+| `@republic using Foo` | `@republic inherit=true using Foo` |
+| `@republic reexport=true using Foo` | `@republic reexport=true inherit=true using Foo` |
+
+The v1.x default performed wildcard discovery. In v2.0, the baseline is explicit — use `inherit=true` to opt into discovery. `reexport=true` no longer implies `inherit`.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/MurrellGroup/Republic.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/MurrellGroup/Republic.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/MurrellGroup/Republic.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/MurrellGroup/Republic.jl)
 
-> Dependencies united under one public API.
+> Cross-version public API management for Julia packages.
 
 Republic.jl manages Julia's [`public`](https://docs.julialang.org/en/v1.11/base/base/#public) visibility across module boundaries and Julia versions. It provides:
 
@@ -23,7 +23,7 @@ using Republic: @public
 @public @my_macro        # macro name
 ```
 
-Replaces [SciMLPublic.jl](https://github.com/SciML/SciMLPublic.jl) and `@compat public` from [Compat.jl](https://github.com/JuliaLang/Compat.jl). Unlike those packages, Republic tracks declarations for cross-version discovery via `public_names(mod)`.
+Republic replaces `@compat public` from [Compat.jl](https://github.com/JuliaLang/Compat.jl), tracking declarations for cross-version discovery via `public_names(mod)`.
 
 ## `@republic`: Forwarding Public API
 
@@ -36,7 +36,7 @@ Replaces [SciMLPublic.jl](https://github.com/SciML/SciMLPublic.jl) and `@compat 
 
 ### Baseline (no flags)
 
-Marks what you bring in as `public`. No wildcard name discovery.
+Marks what you bring in as `public`.
 
 ```julia
 @republic using Foo                 # exported names → public
@@ -57,7 +57,8 @@ Discovers public-only names upstream. Imports them and marks them `public`.
 Re-exports exported names (instead of marking them `public`). Replaces [Reexport.jl](https://github.com/JuliaLang/Reexport.jl).
 
 ```julia
-@republic reexport=true using Foo   # exported → re-export
+@republic reexport=true using Foo             # exported → re-export
+@republic reexport=true using Foo: pub, exp   # public name `pub` is not exported
 ```
 
 ### Combined: full API forwarding
@@ -101,20 +102,20 @@ These two functions partition a module's API into non-overlapping sets. On Julia
 
 ## Overriding visibility
 
-Julia does not allow a name to be both `public` and `export`ed. Republic respects pre-existing declarations:
+Julia does not allow a name to be marked both `public` and `export`ed. Republic respects pre-existing declarations:
 
 ```julia
 module MyPackage
     using Republic
     export bar                                  # already exported
-    @republic republish=true using Foo          # skips `public bar`
+    @republic inherit=true using Foo            # skips `public bar`
 end
 ```
 
 ```julia
 module MyPackage
     using Republic
-    public bar                                  # already public
+    @public bar                                 # already public
     @republic reexport=true using Foo           # skips `export bar`
 end
 ```
@@ -133,3 +134,5 @@ The v1.x default performed wildcard discovery. In v2.0, the baseline is explicit
 ## Acknowledgments
 
 Republic.jl is derived from [Reexport.jl](https://github.com/JuliaLang/Reexport.jl) by Simon Kornblith (MIT License).
+
+Republic.jl v2 was inspired by `@public` from [CUDACore.jl](https://github.com/JuliaGPU/CUDA.jl/blob/c27d64b2ec32f72e82201364e20b0eb550f11e48/CUDACore/src/utils/public.jl).

--- a/src/Republic.jl
+++ b/src/Republic.jl
@@ -35,7 +35,8 @@ function _get_public_symbols(expr::Expr)
     return symbols
 end
 
-function _is_macro_expr(expr::Expr)
+function _is_macro_expr(expr)
+    expr isa Expr || return false
     Meta.isexpr(expr, :macrocall) || return false
     length(expr.args) == 2 || return false
     expr.args[1] isa Symbol || return false
@@ -44,7 +45,6 @@ function _is_macro_expr(expr::Expr)
     expr.args[2] isa LineNumberNode || return false
     return true
 end
-_is_macro_expr(::Any) = false
 
 """
     @public name

--- a/src/Republic.jl
+++ b/src/Republic.jl
@@ -61,11 +61,7 @@ macro public(symbols_expr)
     mod = __module__
     _ensure_storage(mod)
     append!(_get_storage(mod), syms)
-    @static if VERSION >= v"1.11.0-DEV.469"
-        return esc(Expr(:public, syms...))
-    else
-        return nothing
-    end
+    @static VERSION >= v"1.11.0-DEV.469" ? esc(Expr(:public, syms...)) : nothing
 end
 
 
@@ -104,11 +100,7 @@ end
 # Version-invariant visibility check (exported OR public)
 function _is_visible(mod::Module, name::Symbol)
     Base.isexported(mod, name) && return true
-    @static if VERSION >= v"1.11.0-DEV.469"
-        return Base.ispublic(mod, name)
-    else
-        return name in _get_storage(mod)
-    end
+    @static VERSION >= v"1.11.0-DEV.469" ? Base.ispublic(mod, name) : name in _get_storage(mod)
 end
 
 

--- a/src/Republic.jl
+++ b/src/Republic.jl
@@ -1,47 +1,186 @@
 module Republic
 
+# Syntactically unreachable from user code (# prefix)
+const _PUBLIC_NAMES_KEY = Symbol("#Republic_public_names")
+
+function _ensure_storage(mod::Module)
+    isdefined(mod, _PUBLIC_NAMES_KEY) && return
+    Core.eval(mod, :(const $(_PUBLIC_NAMES_KEY) = Symbol[]))
+end
+
+function _get_storage(mod::Module)
+    isdefined(mod, _PUBLIC_NAMES_KEY) || return Symbol[]
+    Base.invokelatest(getfield, mod, _PUBLIC_NAMES_KEY)::Vector{Symbol}
+end
+
+
+_get_public_symbols(sym::Symbol) = [sym]
+
+function _get_public_symbols(expr::Expr)
+    if _is_macro_expr(expr)
+        return [expr.args[1]]
+    end
+    expr.head === :tuple ||
+        throw(ArgumentError("@public: invalid expression `$expr`. Try `@public foo, bar`"))
+    symbols = Vector{Symbol}(undef, length(expr.args))
+    for (i, arg) in enumerate(expr.args)
+        if arg isa Symbol
+            symbols[i] = arg
+        elseif _is_macro_expr(arg)
+            symbols[i] = arg.args[1]
+        else
+            throw(ArgumentError("@public: cannot mark `$arg` as public"))
+        end
+    end
+    return symbols
+end
+
+function _is_macro_expr(expr::Expr)
+    Meta.isexpr(expr, :macrocall) || return false
+    length(expr.args) == 2 || return false
+    expr.args[1] isa Symbol || return false
+    s = string(expr.args[1])
+    length(s) >= 2 && s[1] == '@' || return false
+    expr.args[2] isa LineNumberNode || return false
+    return true
+end
+_is_macro_expr(::Any) = false
+
 """
-    @republic [reexport=false] using/import ...
+    @public name
+    @public name1, name2, ...
+    @public @macro_name
 
-Mark upstream `public` and `export`ed names as `public` in the current module.
-Public-only names that aren't brought in by `using` are imported automatically.
+Mark names as part of the module's public API.
 
-By default, all names become `public` (not exported). Use `reexport=true` to
-also re-export names that were `export`ed upstream.
+On Julia 1.11+, emits the native `public` keyword. On all versions, tracks
+the names for cross-version discovery via [`public_names`](@ref).
+"""
+macro public(symbols_expr)
+    syms = _get_public_symbols(symbols_expr)
+    mod = __module__
+    _ensure_storage(mod)
+    append!(_get_storage(mod), syms)
+    @static if VERSION >= v"1.11.0-DEV.469"
+        return esc(Expr(:public, syms...))
+    else
+        return nothing
+    end
+end
 
-Supports all `using`/`import` forms, including `as` aliases, blocks, and
-module definitions.
+
+"""
+    exported_names(mod::Module) -> Vector{Symbol}
+
+Return names that are `export`ed from `mod`. Version-invariant.
+
+See also: [`public_names`](@ref)
+"""
+function exported_names(mod::Module)
+    filter(n -> Base.isexported(mod, n), names(mod; all=true, imported=true))
+end
+
+"""
+    public_names(mod::Module) -> Vector{Symbol}
+
+Return names that are `public` but not `export`ed in `mod`. Version-invariant.
+
+On Julia 1.11+, uses `Base.ispublic`. On earlier versions, reads from
+Republic's internal per-module storage (populated by [`@public`](@ref) and
+[`@republic`](@ref)).
+
+The result is non-overlapping with [`exported_names`](@ref) — together they
+form the complete public API of a module.
+"""
+function public_names(mod::Module)
+    @static if VERSION >= v"1.11.0-DEV.469"
+        filter(n -> Base.ispublic(mod, n) && !Base.isexported(mod, n),
+               names(mod; all=true, imported=true))
+    else
+        filter(n -> !Base.isexported(mod, n), _get_storage(mod))
+    end
+end
+
+# Version-invariant visibility check (exported OR public)
+function _is_visible(mod::Module, name::Symbol)
+    Base.isexported(mod, name) && return true
+    @static if VERSION >= v"1.11.0-DEV.469"
+        return Base.ispublic(mod, name)
+    else
+        return name in _get_storage(mod)
+    end
+end
+
+
+"""
+    @republic [inherit=true] [reexport=true] using/import ...
+
+Forward upstream names as part of the current module's public API.
+
+**Baseline** (no flags): marks what you bring in as `public`. No wildcard
+name discovery.
+
+**`inherit=true`**: discovers public-only names upstream, imports them, and
+marks them `public`.
+
+**`reexport=true`**: re-exports exported names (instead of marking them
+`public`).
+
+The flags are orthogonal and composable.
 
 # Examples
 
 ```julia
-@republic using Foo                          # Foo's public API becomes public here
-@republic using Foo: bar, baz                # specific names become public
-@republic reexport=true using Foo            # also re-exports exported names
-@republic using Foo: Foo as F                # aliases supported
-@republic begin                              # blocks supported
+@republic using Foo                                # exported names → public
+@republic inherit=true using Foo                   # + public-only names → public
+@republic reexport=true using Foo                  # exported → re-export
+@republic reexport=true inherit=true using Foo     # full API forwarding
+@republic using Foo: bar, baz                      # specific names → public
+@republic reexport=true using Foo: bar             # preserves per-name visibility
+@republic import Foo: bar                          # import semantics + public
+@republic begin                                    # blocks
     using Foo
     using Bar
 end
 ```
 """
 macro republic(ex::Expr)
-    esc(republic(__module__, false, ex))
+    esc(republic(__module__, false, false, ex))
 end
 
-macro republic(reexport_ex::Expr, ex::Expr)
-    reexport_ex.head === :(=) && reexport_ex.args[1] === :reexport ||
-        error("@republic: expected `reexport=true` or `reexport=false`, got `$reexport_ex`")
-    reexport = reexport_ex.args[2]::Bool
-    esc(republic(__module__, reexport, ex))
+macro republic(flag_ex::Expr, ex::Expr)
+    name, value = _parse_flag(flag_ex)
+    inherit = name === :inherit && value
+    reexport = name === :reexport && value
+    esc(republic(__module__, inherit, reexport, ex))
 end
 
-republic(m::Module, reexport::Bool, l::LineNumberNode) = l
+macro republic(flag1::Expr, flag2::Expr, ex::Expr)
+    n1, v1 = _parse_flag(flag1)
+    n2, v2 = _parse_flag(flag2)
+    n1 !== n2 || error("@republic: duplicate flag `$n1`")
+    inherit = (n1 === :inherit ? v1 : v2)
+    reexport = (n1 === :reexport ? v1 : v2)
+    esc(republic(__module__, inherit, reexport, ex))
+end
 
-function republic(m::Module, reexport::Bool, ex::Expr)
+function _parse_flag(ex::Expr)
+    ex.head === :(=) && ex.args[1] isa Symbol ||
+        error("@republic: expected `flag=value`, got `$ex`")
+    name = ex.args[1]::Symbol
+    name in (:inherit, :reexport) ||
+        error("@republic: unknown flag `$name`. Expected `inherit` or `reexport`")
+    value = ex.args[2]::Bool
+    return name, value
+end
+
+
+republic(m::Module, inherit::Bool, reexport::Bool, l::LineNumberNode) = l
+
+function republic(m::Module, inherit::Bool, reexport::Bool, ex::Expr)
     ex = macroexpand(m, ex)
     if ex.head === :block
-        return Expr(:block, map(e -> republic(m, reexport, e), ex.args)...)
+        return Expr(:block, map(e -> republic(m, inherit, reexport, e), ex.args)...)
     end
 
     ex.head::Symbol in (:module, :using, :import) ||
@@ -58,13 +197,15 @@ function republic(m::Module, reexport::Bool, ex::Expr)
     if ex.head === :module
         modules = Any[ex.args[2]]
         ex = Expr(:toplevel, ex, :(using .$(ex.args[2])))
+        # Module form always inherits public-only names
+        inherit = true
     elseif ex.head::Symbol in (:using, :import) && ex.args[1].head === :(:)
         # @republic {using, import} Foo: bar, baz, qux as q
         path_parts = ex.args[1].args[1].args
         orig_names, local_names = _extract_names(ex.args[1].args[2:end])
         return Expr(:toplevel, ex,
             :($_republish_syms($eval, $m, $_resolve($m, $(QuoteNode(path_parts))),
-                $(QuoteNode(orig_names)), $(QuoteNode(local_names)), $reexport)))
+                $(QuoteNode(orig_names)), $(QuoteNode(local_names)), $inherit, $reexport)))
     elseif ex.head === :import && all(e -> e.head in (:., :as), ex.args)
         # @republic import Foo.bar, Baz.qux, Pkg as P
         out = Expr(:toplevel, ex)
@@ -79,13 +220,13 @@ function republic(m::Module, reexport::Bool, ex::Expr)
             orig_name = path.args[end]
             path_parts = path.args[1:end-1]
             if isempty(path_parts)
-                # `import Foo as Bar` — module import
+                # `import Foo` or `import Foo as Bar` — module import
                 _mark = reexport ? _mark_exp : _mark_pub
                 push!(out.args, :($_mark($eval, $m, [$(QuoteNode(local_name))])))
             else
                 push!(out.args,
                     :($_republish_syms($eval, $m, $_resolve($m, $(QuoteNode(path_parts))),
-                        $(QuoteNode([orig_name])), $(QuoteNode([local_name])), $reexport)))
+                        $(QuoteNode([orig_name])), $(QuoteNode([local_name])), $inherit, $reexport)))
             end
         end
         return out
@@ -96,10 +237,11 @@ function republic(m::Module, reexport::Bool, ex::Expr)
 
     out = Expr(:toplevel, ex)
     for mod in modules
-        push!(out.args, :($_republish($eval, $m, $mod, $reexport)))
+        push!(out.args, :($_republish($eval, $m, $mod, $inherit, $reexport)))
     end
     return out
 end
+
 
 function _extract_names(entries)
     orig_names = Symbol[]
@@ -139,57 +281,62 @@ function resolve_module(m::Module, parts)
 end
 
 function _resolve_root(m::Module, name::Symbol)
-    # Base and Core are always available but aren't packages, so
-    # Base.root_module can't find them from all module contexts.
     name === :Base && return Base
     name === :Core && return Core
     return Base.root_module(m, name)
 end
 
-function _mark_public(eval, m::Module, names::Vector{Symbol})
+
+function _mark_public(eval, m::Module, nms::Vector{Symbol})
     # Filter out names already exported in m — Julia errors on public-after-export
-    filter!(n -> !Base.isexported(m, n), names)
-    isempty(names) || eval(m, Expr(:public, names...))
-end
-
-function _mark_exported(eval, m::Module, names::Vector{Symbol})
-    # Filter out names already public (not exported) in m — Julia errors on export-after-public
-    filter!(n -> !Base.ispublic(m, n) || Base.isexported(m, n), names)
-    isempty(names) || eval(m, Expr(:export, names...))
-end
-
-function republish_names(eval, m::Module, upstream::Module, reexport::Bool)
-    exported = Symbol[]
-    public_only = Symbol[]
-    for name in names(upstream; all=true, imported=true)
-        if Base.isexported(upstream, name)
-            push!(exported, name)
-        elseif Base.ispublic(upstream, name)
-            push!(public_only, name)
-        end
+    filter!(n -> !Base.isexported(m, n), nms)
+    isempty(nms) && return
+    # Always track for cross-version discovery
+    _ensure_storage(m)
+    append!(_get_storage(m), nms)
+    # Emit native keyword on 1.11+
+    @static if VERSION >= v"1.11.0-DEV.469"
+        eval(m, Expr(:public, nms...))
     end
+end
+
+function _mark_exported(eval, m::Module, nms::Vector{Symbol})
+    @static if VERSION >= v"1.11.0-DEV.469"
+        # Filter out names already public (not exported) in m — Julia errors on export-after-public
+        filter!(n -> !Base.ispublic(m, n) || Base.isexported(m, n), nms)
+    end
+    isempty(nms) && return
+    eval(m, Expr(:export, nms...))
+end
+
+function republish_names(eval, m::Module, upstream::Module, inherit::Bool, reexport::Bool)
+    exp = collect(exported_names(upstream))
     if reexport
-        _mark_exported(eval, m, exported)
+        _mark_exported(eval, m, exp)
     else
-        _mark_public(eval, m, exported)
+        _mark_public(eval, m, exp)
     end
-    # Import public-only names so they're actual bindings, then mark public
-    for name in public_only
-        eval(m, Expr(:using, Expr(:(:), Expr(:., fullname(upstream)...), Expr(:., name))))
+    # Inherit: also discover and import public-only names
+    if inherit
+        pub = collect(public_names(upstream))
+        fqn = fullname(upstream)
+        for name in pub
+            eval(m, Expr(:using, Expr(:(:), Expr(:., fqn...), Expr(:., name))))
+        end
+        _mark_public(eval, m, pub)
     end
-    _mark_public(eval, m, public_only)
     nothing
 end
 
 function republish_symbols(eval, m::Module, upstream::Module,
                            orig_names::Vector{Symbol}, local_names::Vector{Symbol},
-                           reexport::Bool)
+                           inherit::Bool, reexport::Bool)
     exported = Symbol[]
     public_only = Symbol[]
     for (orig, local_name) in zip(orig_names, local_names)
         if reexport && Base.isexported(upstream, orig)
             push!(exported, local_name)
-        elseif Base.ispublic(upstream, orig)
+        elseif _is_visible(upstream, orig)
             push!(public_only, local_name)
         end
     end
@@ -198,6 +345,7 @@ function republish_symbols(eval, m::Module, upstream::Module,
     nothing
 end
 
-export @republic
+export @republic, @public
+@public public_names, exported_names
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,17 @@ end
     @test Symbol("@mymac") in public_names(Pub3)
 end
 
+module Pub4
+    using Republic: @public
+    const A = 1
+    macro mymac() end
+    @public A, @mymac
+end
+@testset "@public: mixed tuple with macro" begin
+    @test :A in public_names(Pub4)
+    @test Symbol("@mymac") in public_names(Pub4)
+end
+
 #=== Discovery API ===#
 
 module Disc1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,67 @@
-using Republic
+using Republic: Republic, @republic, @public, public_names, exported_names
 using Test
 
-# Helpers
-public_set(m::Module) = Set(filter(x -> Base.ispublic(m, x), names(m; all=true, imported=true)))
-exported_set(m::Module) = Set(filter(x -> Base.isexported(m, x), names(m; all=true, imported=true)))
+#=== @public macro ===#
 
-#=== Default behavior: everything becomes public ===#
+module Pub1
+    using Republic: @public
+    const A = 1
+    @public A
+end
+@testset "@public: single name" begin
+    @test :A in public_names(Pub1)
+    @test !Base.isexported(Pub1, :A)
+end
+
+module Pub2
+    using Republic: @public
+    const X = 1; const Y = 2; const Z = 3
+    @public X, Y, Z
+end
+@testset "@public: tuple" begin
+    @test Set([:X, :Y, :Z]) ⊆ Set(public_names(Pub2))
+end
+
+module Pub3
+    using Republic: @public
+    macro mymac() end
+    @public @mymac
+end
+@testset "@public: macro name" begin
+    @test Symbol("@mymac") in public_names(Pub3)
+end
+
+#=== Discovery API ===#
+
+module Disc1
+    using Republic: @public
+    const E = 1; const P = 2; const _Priv = 3
+    export E
+    @public P
+end
+@testset "exported_names / public_names" begin
+    @test :E in exported_names(Disc1)
+    @test :P in public_names(Disc1)
+    @test !(:E in public_names(Disc1))   # non-overlapping
+    @test !(:P in exported_names(Disc1))
+    @test !(:_Priv in exported_names(Disc1))
+    @test !(:_Priv in public_names(Disc1))
+end
+
+#=== Internal storage ===#
+
+module Store1
+    using Republic: @public
+    const S = 1
+    @public S
+end
+@testset "storage: gensym key, no user-visible binding" begin
+    @test !isdefined(Store1, :PUBLIC_NAMES)
+    @test isdefined(Store1, Symbol("#Republic_public_names"))
+    @test :S in getfield(Store1, Symbol("#Republic_public_names"))
+end
+
+#=== Baseline behavior: marks what you bring in ===#
 
 module Y1
     const Z1 = 1
@@ -15,25 +71,37 @@ module X1
     using Republic
     @republic using Main.Y1
 end
-@testset "default: exported upstream → public (not re-exported)" begin
-    @test :Z1 in public_set(X1)
+@testset "baseline: exported upstream → public" begin
+    @test :Z1 in public_names(X1)
     @test !Base.isexported(X1, :Z1)
     @test X1.Z1 == 1
 end
 
 module Y2
+    using Republic: @public
     const A = 1
     const B = 2
     export A
-    public B
+    @public B
 end
-module X2
+module X2_baseline
     using Republic
     @republic using Main.Y2
 end
-@testset "default: exported + public → all public" begin
-    @test :A in public_set(X2)
-    @test :B in public_set(X2)
+@testset "baseline: public-only names NOT imported" begin
+    @test :A in public_names(X2_baseline)
+    @test !(:B in public_names(X2_baseline))
+end
+
+#=== inherit=true: wildcard discovery ===#
+
+module X2
+    using Republic
+    @republic inherit=true using Main.Y2
+end
+@testset "inherit=true: exported + public → all public" begin
+    @test :A in public_names(X2)
+    @test :B in public_names(X2)
     @test !Base.isexported(X2, :A)
     @test !Base.isexported(X2, :B)
     @test X2.A == 1
@@ -46,16 +114,17 @@ module Y3
     export Z3
 end
 module Y4
+    using Republic: @public
     const Z4 = 4
-    public Z4
+    @public Z4
 end
 module X3
     using Republic
-    @republic using Main.Y3, Main.Y4
+    @republic inherit=true using Main.Y3, Main.Y4
 end
-@testset "default: multiple modules" begin
-    @test :Z3 in public_set(X3)
-    @test :Z4 in public_set(X3)
+@testset "inherit=true: multiple modules" begin
+    @test :Z3 in public_names(X3)
+    @test :Z4 in public_names(X3)
     @test !Base.isexported(X3, :Z3)
     @test !Base.isexported(X3, :Z4)
     @test X3.Z3 == 3
@@ -64,18 +133,19 @@ end
 
 # Colon-qualified
 module Y5
+    using Republic: @public
     const Z5 = 5
     const Z6 = 6
     export Z5
-    public Z6
+    @public Z6
 end
 module X4
     using Republic
     @republic using Main.Y5: Z5, Z6
 end
-@testset "default: colon-qualified → all public" begin
-    @test :Z5 in public_set(X4)
-    @test :Z6 in public_set(X4)
+@testset "baseline: colon-qualified → all public" begin
+    @test :Z5 in public_names(X4)
+    @test :Z6 in public_names(X4)
     @test !Base.isexported(X4, :Z5)
     @test !Base.isexported(X4, :Z6)
     @test X4.Z5 == 5
@@ -83,7 +153,6 @@ end
 end
 
 # Colon-qualified where module is NOT a binding in the current module
-# (mimics `@republic using SomePackage: name` in a real package)
 module _Wrapper
     module Hidden
         const H = 42
@@ -92,33 +161,31 @@ module _Wrapper
 end
 module X4b
     using Republic
-    # _Wrapper.Hidden is not a binding in X4b — only H is brought in
     @republic using Main._Wrapper.Hidden: H
 end
-@testset "default: colon-qualified, module not in scope" begin
-    @test :H in public_set(X4b)
+@testset "baseline: colon-qualified, module not in scope" begin
+    @test :H in public_names(X4b)
     @test X4b.H == 42
 end
 
-# Colon-qualified: explicit names are always republished (even if private upstream,
-# since pre-1.11 packages may not have `public` declarations for documented API)
+# Colon-qualified: private names not publicized
 module Y_priv
+    using Republic: @public
     const A = 1
     const B = 2
     const _C = 3
     export A
-    public B
-    # _C is private
+    @public B
 end
 module X_priv
     using Republic
     @republic using Main.Y_priv: A, B, _C
 end
 @testset "colon-qualified: mirrors upstream visibility" begin
-    @test :A in public_set(X_priv)
-    @test :B in public_set(X_priv)
-    @test !Base.ispublic(X_priv, :_C)  # private upstream → not made public
-    @test X_priv._C == 3               # but still imported
+    @test :A in public_names(X_priv)
+    @test :B in public_names(X_priv)
+    @test !(:_C in public_names(X_priv))  # private upstream → not made public
+    @test X_priv._C == 3                   # but still imported
 end
 
 # Import dot-qualified
@@ -127,16 +194,17 @@ module Y6
     export Z7
 end
 module Y6b
+    using Republic: @public
     const Z8 = 8
-    public Z8
+    @public Z8
 end
 module X5
     using Republic
     @republic import Main.Y6.Z7, Main.Y6b.Z8
 end
-@testset "default: import dot-qualified → all public" begin
-    @test :Z7 in public_set(X5)
-    @test :Z8 in public_set(X5)
+@testset "baseline: import dot-qualified → all public" begin
+    @test :Z7 in public_names(X5)
+    @test :Z8 in public_names(X5)
     @test !Base.isexported(X5, :Z7)
     @test !Base.isexported(X5, :Z8)
     @test X5.Z7 == 7
@@ -146,31 +214,32 @@ end
 # Block syntax
 module X6
     using Republic
-    @republic begin
+    @republic inherit=true begin
         using Main.Y3
         using Main.Y4
     end
 end
-@testset "default: block syntax" begin
-    @test :Z3 in public_set(X6)
-    @test :Z4 in public_set(X6)
+@testset "inherit=true: block syntax" begin
+    @test :Z3 in public_names(X6)
+    @test :Z4 in public_names(X6)
     @test !Base.isexported(X6, :Z3)
 end
 
-# Module definition
+# Module definition (always inherits)
 module X7
     using Republic
     @republic module Inner
+        using Republic: @public
         const W = 42
         export W
         const V = 99
-        public V
+        @public V
     end
 end
-@testset "default: module definition → all public" begin
-    @test :Inner in public_set(X7)
-    @test :W in public_set(X7)
-    @test :V in public_set(X7)
+@testset "module definition → all public (always inherits)" begin
+    @test :Inner in public_names(X7)
+    @test :W in public_names(X7)
+    @test :V in public_names(X7)
     @test !Base.isexported(X7, :W)
     @test !Base.isexported(X7, :V)
     @test X7.W == 42
@@ -179,18 +248,19 @@ end
 
 # as aliases
 module Y_as
+    using Republic: @public
     const E = 1
     const P = 2
     export E
-    public P
+    @public P
 end
 module X_as
     using Republic
     @republic using Main.Y_as: E as Alias_E, P as Alias_P
 end
-@testset "default: as aliases → all public" begin
-    @test :Alias_E in public_set(X_as)
-    @test :Alias_P in public_set(X_as)
+@testset "baseline: as aliases → all public" begin
+    @test :Alias_E in public_names(X_as)
+    @test :Alias_P in public_names(X_as)
     @test !Base.isexported(X_as, :Alias_E)
     @test X_as.Alias_E == 1
     @test X_as.Alias_P == 2
@@ -198,18 +268,19 @@ end
 
 # import Module as Alias (dotted path — upstream visibility matters)
 module Y_mod_as_wrap
+    using Republic: @public
     module Y_mod_as
         const Q = 1
         export Q
     end
-    public Y_mod_as
+    @public Y_mod_as
 end
 module X_mod_as
     using Republic
     @republic import Main.Y_mod_as_wrap.Y_mod_as as YMA
 end
-@testset "default: import Module as Alias → public" begin
-    @test :YMA in public_set(X_mod_as)
+@testset "baseline: import Module as Alias → public" begin
+    @test :YMA in public_names(X_mod_as)
     @test !Base.isexported(X_mod_as, :YMA)
     @test X_mod_as.YMA === Y_mod_as_wrap.Y_mod_as
 end
@@ -219,9 +290,9 @@ module X_dot_as
     using Republic
     @republic import Main.Y_as.E as E2, Main.Y_as.P as P2
 end
-@testset "default: import dot-qualified with alias → all public" begin
-    @test :E2 in public_set(X_dot_as)
-    @test :P2 in public_set(X_dot_as)
+@testset "baseline: import dot-qualified with alias → all public" begin
+    @test :E2 in public_names(X_dot_as)
+    @test :P2 in public_names(X_dot_as)
     @test !Base.isexported(X_dot_as, :E2)
     @test X_dot_as.E2 == 1
     @test X_dot_as.P2 == 2
@@ -242,8 +313,8 @@ module X_macro
 
     @republic @identity_macro using .InnerMacro: A
 end
-@testset "default: macroexpand" begin
-    @test :A in public_set(X_macro)
+@testset "baseline: macroexpand" begin
+    @test :A in public_names(X_macro)
     @test !Base.isexported(X_macro, :A)
 end
 
@@ -251,11 +322,11 @@ end
 
 module XR1
     using Republic
-    @republic reexport=true using Main.Y2
+    @republic reexport=true inherit=true using Main.Y2
 end
-@testset "reexport=true: preserves visibility" begin
-    @test :A in exported_set(XR1)
-    @test :B in public_set(XR1)
+@testset "reexport=true inherit=true: preserves visibility" begin
+    @test :A in exported_names(XR1)
+    @test :B in public_names(XR1)
     @test !Base.isexported(XR1, :B)
     @test XR1.A == 1
     @test XR1.B == 2
@@ -266,8 +337,8 @@ module XR2
     @republic reexport=true using Main.Y5: Z5, Z6
 end
 @testset "reexport=true: colon-qualified preserves visibility" begin
-    @test :Z5 in exported_set(XR2)
-    @test :Z6 in public_set(XR2)
+    @test :Z5 in exported_names(XR2)
+    @test :Z6 in public_names(XR2)
     @test !Base.isexported(XR2, :Z6)
     @test XR2.Z5 == 5
     @test XR2.Z6 == 6
@@ -278,8 +349,8 @@ module XR3
     @republic reexport=true using Main.Y_as: E as RE, P as RP
 end
 @testset "reexport=true: as aliases preserve visibility" begin
-    @test :RE in exported_set(XR3)
-    @test :RP in public_set(XR3)
+    @test :RE in exported_names(XR3)
+    @test :RP in public_names(XR3)
     @test !Base.isexported(XR3, :RP)
     @test XR3.RE == 1
     @test XR3.RP == 2
@@ -290,8 +361,8 @@ module XR4
     @republic reexport=true import Main.Y6.Z7, Main.Y6b.Z8
 end
 @testset "reexport=true: import dot-qualified preserves visibility" begin
-    @test :Z7 in exported_set(XR4)
-    @test :Z8 in public_set(XR4)
+    @test :Z7 in exported_names(XR4)
+    @test :Z8 in public_names(XR4)
     @test !Base.isexported(XR4, :Z8)
 end
 
@@ -306,54 +377,54 @@ module X_reexport
     @republic reexport=true using Main.Y_reexport
 end
 @testset "reexport=true: like Reexport for export-only modules" begin
-    @test :R1 in exported_set(X_reexport)
-    @test :R2 in exported_set(X_reexport)
+    @test :R1 in exported_names(X_reexport)
+    @test :R2 in exported_names(X_reexport)
     @test X_reexport.R1 == 10
     @test X_reexport.R2 == 20
 end
 
-# reexport=true block syntax
+# reexport=true inherit=true block syntax
 module XR5
     using Republic
-    @republic reexport=true begin
+    @republic reexport=true inherit=true begin
         using Main.Y3
         using Main.Y4
     end
 end
-@testset "reexport=true: block syntax" begin
-    @test :Z3 in exported_set(XR5)
-    @test :Z4 in public_set(XR5)
+@testset "reexport=true inherit=true: block syntax" begin
+    @test :Z3 in exported_names(XR5)
+    @test :Z4 in public_names(XR5)
     @test !Base.isexported(XR5, :Z4)
     @test XR5.Z3 == 3
     @test XR5.Z4 == 4
 end
 
-# reexport=true with bare import Module as Alias (single-element path)
+# reexport=true with bare import Module as Alias
 module XR6
     using Republic
     @republic reexport=true import Test as T
 end
 @testset "reexport=true: bare import as Alias → exported" begin
-    @test :T in exported_set(XR6)
+    @test :T in exported_names(XR6)
 end
 
-# Using Base and Core directly (not package-managed modules)
+# Using Base and Core directly
 module X_base
     using Republic
-    @republic using Base: IdSet
+    @republic using Base: Dict
 end
 module X_core
     using Republic
     @republic using Core: Int32
 end
 @testset "using Base/Core modules" begin
-    @test :IdSet in public_set(X_base)
-    @test X_base.IdSet === Base.IdSet
-    @test :Int32 in public_set(X_core)
+    @test :Dict in public_names(X_base)
+    @test X_base.Dict === Base.Dict
+    @test :Int32 in public_names(X_core)
     @test X_core.Int32 === Core.Int32
 end
 
-# Double-dot relative path (..Module)
+# Double-dot relative path
 module Outer
     module Inner
         const X = 1
@@ -365,7 +436,7 @@ module Outer
     end
 end
 @testset "double-dot relative path" begin
-    @test :X in public_set(Outer.Mid)
+    @test :X in public_names(Outer.Mid)
     @test Outer.Mid.X == 1
 end
 
@@ -395,8 +466,7 @@ module X_using_no_ext
     @republic using Main.Y_using_no_ext
 end
 @testset "using does not allow method extension" begin
-    @test :f in public_set(X_using_no_ext)
-    # f should not be extendable — defining f(::Int) should create a NEW function in X, not extend Y's
+    @test :f in public_names(X_using_no_ext)
     Core.eval(X_using_no_ext, :(f(x::Int) = :new))
     @test X_using_no_ext.f(1) == :new                # new function in X
     @test Main.Y_using_no_ext.f !== X_using_no_ext.f  # different functions
@@ -404,53 +474,141 @@ end
 
 # using with public-only names does NOT allow method extension
 module Y_using_pub_no_ext
+    using Republic: @public
     g() = :original
-    public g
+    @public g
 end
 module X_using_pub_no_ext
     using Republic
-    @republic using Main.Y_using_pub_no_ext
+    @republic inherit=true using Main.Y_using_pub_no_ext
 end
 @testset "using public-only names does not allow method extension" begin
-    @test :g in public_set(X_using_pub_no_ext)
-    # g was brought in via `using`, so extending it should error
-    @test_throws "must be explicitly imported to be extended" Core.eval(X_using_pub_no_ext, :(g(x::Int) = :new))
+    @test :g in public_names(X_using_pub_no_ext)
+    @test_throws ErrorException Core.eval(X_using_pub_no_ext, :(g(x::Int) = :new))
 end
 
 # export before @republic is respected
 module Y_export_after
+    using Republic: @public
     const A = 1
     const B = 2
     export A
-    public B
+    @public B
 end
 module X_export_before
     using Republic
     export A  # declare export before @republic — @republic will skip `public` for A
-    @republic using Main.Y_export_after
+    @republic inherit=true using Main.Y_export_after
 end
 @testset "export before @republic is respected" begin
-    @test :A in exported_set(X_export_before)
-    @test :B in public_set(X_export_before)
+    @test :A in exported_names(X_export_before)
+    @test :B in public_names(X_export_before)
     @test X_export_before.A == 1
     @test X_export_before.B == 2
 end
 
-# public before @republic reexport=true is respected
-module Y_public_before
-    const C = 3
-    const D = 4
-    export C, D
+#=== Flag composability ===#
+
+module Y_compose
+    using Republic: @public
+    const A = 1
+    const B = 2
+    export A
+    @public B
 end
-module X_public_before
+module X_compose
     using Republic
-    public C  # declare public before @republic — @republic will skip `export` for C
-    @republic reexport=true using Main.Y_public_before
+    @republic reexport=true inherit=true using Main.Y_compose
 end
-@testset "public before @republic reexport=true is respected" begin
-    @test :C in public_set(X_public_before)
-    @test !Base.isexported(X_public_before, :C)  # stayed public, not promoted to export
-    @test :D in exported_set(X_public_before)
-    @test X_public_before.C == 3
-    @test X_public_before.D == 4
+@testset "reexport + inherit compose" begin
+    @test :A in exported_names(X_compose)   # exported → re-exported
+    @test :B in public_names(X_compose)     # public → imported + public
+    @test !Base.isexported(X_compose, :B)
+    @test X_compose.A == 1
+    @test X_compose.B == 2
+end
+
+# reexport=true alone does NOT import public-only names
+module X_reexport_only
+    using Republic
+    @republic reexport=true using Main.Y_compose
+end
+@testset "reexport alone: no public-only import" begin
+    @test :A in exported_names(X_reexport_only)
+    @test !(:B in public_names(X_reexport_only))
+end
+
+@testset "duplicate flag is an error" begin
+    @test_throws Exception @macroexpand @republic inherit=true inherit=true using Foo
+end
+
+#=== Storage tracking by @republic ===#
+
+module Y_track
+    const T1 = 1
+    export T1
+end
+module X_track
+    using Republic
+    @republic using Main.Y_track
+end
+@testset "storage: @republic baseline tracks in storage" begin
+    @test :T1 in public_names(X_track)
+    @test isdefined(X_track, Symbol("#Republic_public_names"))
+end
+
+#=== Module definition with reexport=true ===#
+
+module X7r
+    using Republic
+    @republic reexport=true module Inner
+        using Republic: @public
+        const W = 42
+        export W
+        const V = 99
+        @public V
+    end
+end
+@testset "module definition reexport=true: preserves visibility" begin
+    @test :Inner in exported_names(X7r) # module self-exports → re-exported
+    @test :W in exported_names(X7r)    # exported → re-exported
+    @test :V in public_names(X7r)      # public → stays public
+    @test X7r.W == 42
+    @test X7r.V == 99
+end
+
+#=== Propagation chain ===#
+
+module Chain_A
+    using Republic: @public
+    const FA = 1
+    export FA
+    const PA = 2
+    @public PA
+end
+module Chain_B
+    using Republic
+    @republic inherit=true using Main.Chain_A
+end
+module Chain_C
+    using Republic
+    @republic inherit=true using Main.Chain_B
+end
+@testset "propagation: A → B → C" begin
+    # B gets both FA (exported) and PA (public) from A, marks all public
+    @test :FA in public_names(Chain_B)
+    @test :PA in public_names(Chain_B)
+    @test Chain_B.FA == 1
+    @test Chain_B.PA == 2
+    # C inherits from B — FA and PA are public-only in B → public in C
+    @test :FA in public_names(Chain_C)
+    @test :PA in public_names(Chain_C)
+    @test Chain_C.FA == 1
+    @test Chain_C.PA == 2
+end
+
+#=== Julia 1.11+ tests (native `public` keyword) ===#
+
+if VERSION >= v"1.11.0-DEV.469"
+    include("runtests_1_11.jl")
 end

--- a/test/runtests_1_11.jl
+++ b/test/runtests_1_11.jl
@@ -1,0 +1,66 @@
+# Tests requiring Julia 1.11+ (native `public` keyword)
+
+using Republic: @republic, public_names, exported_names
+using Test
+
+# public before @republic reexport=true is respected
+module Y_public_before
+    const C = 3
+    const D = 4
+    export C, D
+end
+module X_public_before
+    using Republic
+    public C  # declare public before @republic — @republic will skip `export` for C
+    @republic reexport=true using Main.Y_public_before
+end
+@testset "1.11: public before @republic reexport=true is respected" begin
+    @test :C in public_names(X_public_before)
+    @test !Base.isexported(X_public_before, :C)  # stayed public, not promoted to export
+    @test :D in exported_names(X_public_before)
+    @test X_public_before.C == 3
+    @test X_public_before.D == 4
+end
+
+# Native `public` declarations are discoverable by Republic
+module Y_native_pub
+    const A = 1
+    const B = 2
+    const _C = 3
+    export A
+    public B
+end
+module X_native_pub
+    using Republic
+    @republic inherit=true using Main.Y_native_pub
+end
+@testset "1.11: native public keyword discoverable by @republic" begin
+    @test :A in public_names(X_native_pub)
+    @test :B in public_names(X_native_pub)
+    @test !(:_C in public_names(X_native_pub))
+    @test X_native_pub.A == 1
+    @test X_native_pub.B == 2
+end
+
+# Colon-qualified with native public names
+module X_native_colon
+    using Republic
+    @republic using Main.Y_native_pub: A, B, _C
+end
+@testset "1.11: colon-qualified with native public" begin
+    @test :A in public_names(X_native_colon)
+    @test :B in public_names(X_native_colon)
+    @test !(:_C in public_names(X_native_colon))  # private → not marked
+    @test X_native_colon._C == 3                    # but still imported
+end
+
+# reexport=true with native public preserves visibility
+module X_native_reexport
+    using Republic
+    @republic reexport=true inherit=true using Main.Y_native_pub
+end
+@testset "1.11: reexport with native public preserves visibility" begin
+    @test :A in exported_names(X_native_reexport)
+    @test :B in public_names(X_native_reexport)
+    @test !Base.isexported(X_native_reexport, :B)
+end


### PR DESCRIPTION
- `@public` macro
- `inherit` keyword for `@republic`
- Public `public_names` and `exported_names` helpers

Closes #6

The changes are breaking, because v1.0.0 behaved like `inherit=true` for `using` and `import` (and was documented as such) while v1.0.1 behaved like `inherit=true` for `using` and `inherit=false`. I regret registering v1.0.1 as a patch, since it was clearly breaking due to the inheritance being documented in the README of v1.0.0, but it has now been a few weeks since, so I'm torn on what or if a v1.0.2 should be.