### PR TITLE
Support `inherit=true import` for wildcard discovery with import semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,29 @@ using Republic: @public
 
 ## `@republic`: Forwarding Public API
 
-`@republic` has three orthogonal, composable flags:
+`@republic` preserves `using`/`import` semantics and has three orthogonal, composable flags:
 
-- **`inherit`** — whether to discover and import public-only names from upstream
-- **`reexport`** — whether to re-export (instead of marking `public`) exported names
-- **`republic`** — whether to mark imported names as `public` (default: `true`)
+- **`inherit`** — discover and import public-only names from upstream (default: `false`)
+- **`reexport`** — re-export exported names instead of marking them `public` (default: `false`)
+- **`republic`** — mark imported names as `public` (default: `true`)
 
-| | `inherit=false` (default) | `inherit=true` |
-|---|---|---|
-| **default** | exported → `public` | exported → `public`, public-only → import + `public` |
-| **`reexport=true`** | exported → re-`export` | exported → re-`export`, public-only → import + `public` |
-| **`republic=false`** | (plain `using`) | public-only → import (not marked) |
+### `using` vs `import`
+
+`@republic` preserves Julia's native `using`/`import` distinction:
+
+- **`using`** brings names into scope for *use* (no method extension)
+- **`import`** brings names into scope for *extension* (methods can be added)
+
+With `inherit=true`, this extends to wildcard discovery:
+
+```julia
+@republic inherit=true using Foo    # all API names available, using semantics
+@republic inherit=true import Foo   # all API names available, import semantics (method extension)
+```
 
 ### Baseline (no flags)
 
-Marks what you bring in as `public`.
+Marks what you bring in as `public`. No wildcard name discovery.
 
 ```julia
 @republic using Foo                 # exported names → public
@@ -51,10 +59,11 @@ Marks what you bring in as `public`.
 
 ### `inherit=true`
 
-Discovers public-only names upstream. Imports them and marks them `public`.
+Discovers public-only names upstream, imports them, and marks them `public`.
 
 ```julia
-@republic inherit=true using Foo    # all API names → public
+@republic inherit=true using Foo    # all API names → public (using semantics)
+@republic inherit=true import Foo   # all API names → public (import semantics)
 ```
 
 ### `reexport=true`
@@ -62,8 +71,8 @@ Discovers public-only names upstream. Imports them and marks them `public`.
 Re-exports exported names (instead of marking them `public`). Replaces [Reexport.jl](https://github.com/JuliaLang/Reexport.jl).
 
 ```julia
-@republic reexport=true using Foo             # exported → re-export
-@reexport using Foo                           # equivalent shorthand
+@republic reexport=true using Foo   # exported → re-export
+@reexport using Foo                 # equivalent shorthand
 ```
 
 ### `republic=false`
@@ -71,7 +80,8 @@ Re-exports exported names (instead of marking them `public`). Replaces [Reexport
 Suppresses the `public` marking. Useful with `inherit=true` for importing the full upstream public API without republishing it.
 
 ```julia
-@republic republic=false inherit=true using Foo  # import full API, keep private
+@republic republic=false inherit=true using Foo     # import full API, keep private
+@republic republic=false inherit=true import Foo    # same, with import semantics
 ```
 
 ### Combined: full API forwarding

--- a/src/Republic.jl
+++ b/src/Republic.jl
@@ -213,6 +213,7 @@ function republic(m::Module, inherit::Bool, reexport::Bool, do_republic::Bool, e
     _resolve = GlobalRef(@__MODULE__, :resolve_module)
     _mark_pub = GlobalRef(@__MODULE__, :_mark_public)
     _mark_exp = GlobalRef(@__MODULE__, :_mark_exported)
+    _reimport = GlobalRef(@__MODULE__, :_try_reimport)
 
     if ex.head === :module
         modules = Any[ex.args[2]]
@@ -225,7 +226,7 @@ function republic(m::Module, inherit::Bool, reexport::Bool, do_republic::Bool, e
         orig_names, local_names = _extract_names(ex.args[1].args[2:end])
         return Expr(:toplevel, ex,
             :($_republish_syms($eval, $m, $_resolve($m, $(QuoteNode(path_parts))),
-                $(QuoteNode(orig_names)), $(QuoteNode(local_names)), $inherit, $reexport, $do_republic)))
+                $(QuoteNode(orig_names)), $(QuoteNode(local_names)), $reexport, $do_republic)))
     elseif ex.head === :import && all(e -> e.head in (:., :as), ex.args)
         # @republic import Foo.bar, Baz.qux, Pkg as P
         out = Expr(:toplevel, ex)
@@ -249,7 +250,11 @@ function republic(m::Module, inherit::Bool, reexport::Bool, do_republic::Bool, e
             else
                 push!(out.args,
                     :($_republish_syms($eval, $m, $_resolve($m, $(QuoteNode(path_parts))),
-                        $(QuoteNode([orig_name])), $(QuoteNode([local_name])), $inherit, $reexport, $do_republic)))
+                        $(QuoteNode([orig_name])), $(QuoteNode([local_name])), $reexport, $do_republic)))
+            end
+            if inherit
+                push!(out.args, :($_reimport($eval, $m, $(QuoteNode(local_name)),
+                    $reexport, $do_republic)))
             end
         end
         return out
@@ -334,13 +339,13 @@ end
 
 function republish_names(eval, m::Module, upstream::Module, inherit::Bool, reexport::Bool, do_republic::Bool=true)
     if reexport
-        _mark_exported(eval, m, collect(exported_names(upstream)))
+        _mark_exported(eval, m, exported_names(upstream))
     elseif do_republic
-        _mark_public(eval, m, collect(exported_names(upstream)))
+        _mark_public(eval, m, exported_names(upstream))
     end
     # Inherit: also discover and import public-only names
     if inherit
-        pub = collect(public_names(upstream))
+        pub = public_names(upstream)
         fqn = fullname(upstream)
         for name in pub
             eval(m, Expr(:using, Expr(:(:), Expr(:., fqn...), Expr(:., name))))
@@ -350,9 +355,33 @@ function republish_names(eval, m::Module, upstream::Module, inherit::Bool, reexp
     nothing
 end
 
+function _try_reimport(eval, m::Module, name::Symbol, reexport::Bool, do_republic::Bool)
+    isdefined(m, name) || return nothing
+    val = getfield(m, name)
+    val isa Module || return nothing
+    reimport_names(eval, m, val, reexport, do_republic)
+end
+
+function reimport_names(eval, m::Module, upstream::Module, reexport::Bool, do_republic::Bool)
+    fqn = fullname(upstream)
+    exp = exported_names(upstream)
+    pub = public_names(upstream)
+    # Import all visible names with import semantics (method extension possible)
+    for name in Iterators.flatten((exp, pub))
+        eval(m, Expr(:import, Expr(:(:), Expr(:., fqn...), Expr(:., name))))
+    end
+    if reexport
+        _mark_exported(eval, m, exp)
+    elseif do_republic
+        _mark_public(eval, m, exp)
+    end
+    do_republic && _mark_public(eval, m, pub)
+    nothing
+end
+
 function republish_symbols(eval, m::Module, upstream::Module,
                            orig_names::Vector{Symbol}, local_names::Vector{Symbol},
-                           inherit::Bool, reexport::Bool, do_republic::Bool=true)
+                           reexport::Bool, do_republic::Bool=true)
     exported = Symbol[]
     public_only = Symbol[]
     for (orig, local_name) in zip(orig_names, local_names)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -618,6 +618,76 @@ end
     @test Chain_C.PA == 2
 end
 
+#=== inherit=true with bare import ===#
+
+module Y_bare_import
+    using Republic: @public
+    f() = :original
+    const A = 1
+    export f
+    @public A
+end
+module X_bare_import
+    using Republic
+    @republic inherit=true import Main.Y_bare_import
+    f(x::Int) = :extended  # method extension — import semantics
+end
+@testset "inherit=true import: imports all visible names with import semantics" begin
+    @test :f in public_names(X_bare_import)               # exported upstream
+    @test :A in public_names(X_bare_import)               # public upstream
+    @test X_bare_import.A == 1
+    @test X_bare_import.f() == :original
+    @test X_bare_import.f(1) == :extended
+    @test Main.Y_bare_import.f(1) == :extended  # same function was extended
+end
+
+# Without inherit, bare import only gets the module binding
+module X_bare_import_no_inherit
+    using Republic
+    @republic import Main.Y_bare_import
+end
+@testset "bare import without inherit: only module binding" begin
+    @test !(:f in public_names(X_bare_import_no_inherit))
+    @test !(:A in public_names(X_bare_import_no_inherit))
+end
+
+# inherit=true import with alias
+module X_bare_import_as
+    using Republic
+    @republic inherit=true import Main.Y_bare_import as YBI
+end
+@testset "inherit=true import as alias" begin
+    @test :f in public_names(X_bare_import_as)
+    @test :A in public_names(X_bare_import_as)
+    @test X_bare_import_as.A == 1
+    @test X_bare_import_as.YBI === Main.Y_bare_import
+end
+
+# inherit=true import with reexport=true
+module X_bare_import_reexport
+    using Republic
+    @republic inherit=true reexport=true import Main.Y_bare_import
+end
+@testset "inherit=true import reexport=true: preserves visibility" begin
+    @test :Y_bare_import in exported_names(X_bare_import_reexport)  # module re-exported
+    @test :f in exported_names(X_bare_import_reexport)              # exported upstream → re-exported
+    @test :A in public_names(X_bare_import_reexport)                # public upstream → public
+    @test !Base.isexported(X_bare_import_reexport, :A)
+end
+
+# inherit=true import with republic=false
+module X_bare_import_norepublic
+    using Republic
+    @republic inherit=true republic=false import Main.Y_bare_import
+end
+@testset "inherit=true import republic=false: imports but no marking" begin
+    @test !(:Y_bare_import in public_names(X_bare_import_norepublic))
+    @test !(:f in public_names(X_bare_import_norepublic))
+    @test !(:A in public_names(X_bare_import_norepublic))
+    @test X_bare_import_norepublic.A == 1
+    @test X_bare_import_norepublic.f() == :original
+end
+
 #=== @reexport macro ===#
 
 module XRE1


### PR DESCRIPTION
This was the original behavior of `@republic import` in v1.0.0, dropped in v1.0.1 (my bad), but now it's opt-in. See #6